### PR TITLE
Fixes multiple copies of React

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - "10"
+before_install:
+- npm install react
 script:
   - npm run lint
   - npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -6158,17 +6158,6 @@
         "ret": "~0.1.10"
       }
     },
-    "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
-      }
-    },
     "react-dom": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
@@ -6609,6 +6598,7 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "sinon": "^7.3.2"
   },
   "dependencies": {
-    "prop-types": "^15.7.2",
+    "prop-types": "^15.7.2"
+  },
+  "peerDependencies": {
     "react": "^16.8.6"
   },
   "jest": {


### PR DESCRIPTION
When _use-error-boundary_ is installed in an app, it causes React to throw an "Invalid hook call" error because React is also a dependency of this package, e.g.:

```
Uncaught Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.
    at resolveDispatcher (VM4735 react.development.js:1431)
    at useReducer (VM4735 react.development.js:1466)
    at useErrorBoundary (use-error-boundary.js:95)
    …
```

This changes _package.json_ to list React as a peer dependency so the consuming app can provide its own.