### PR TITLE
[Release 2.0.5] Reset error state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # use-error-boundary
 
 [![npm version](https://img.shields.io/npm/v/use-error-boundary.svg)](https://www.npmjs.com/package/use-error-boundary)
-![build status](https://travis-ci.org/JoschuaSchneider/use-error-boundary.svg?branch=master)
+![TypeScript](https://badgen.net/badge/-/TypeScript/blue?icon=typescript&label)
+![build workflow](https://github.com/JoschuaSchneider/use-error-boundary/actions/workflows/build.yml/badge.svg?branch=master)
+![test workflow](https://github.com/JoschuaSchneider/use-error-boundary/actions/workflows/test.yml/badge.svg?branch=master)
 ![license](https://img.shields.io/npm/l/use-error-boundary.svg)
 
 A **react hook** for using error boundaries in your functional components.
 
-It lets you keep track of the error state of child components, by wrapping them in a provided `ErrorBoundary` component.
+It lets you keep track of the error state of child components, by wrapping them in the provided `ErrorBoundary` component.
 
-:warning: Read more about error boundaries and their intended use in the [React documentation](https://reactjs.org/docs/error-boundaries.html), this will only catch errors when rendering your children!
+:warning: Read more about error boundaries and their intended use in the [React documentation](https://reactjs.org/docs/error-boundaries.html), this will only catch errors during the render phase!
 
 ### Installation
 
@@ -16,12 +18,16 @@ It lets you keep track of the error state of child components, by wrapping them 
 npm i use-error-boundary
 ```
 
+```bash
+yarn add use-error-boundary
+```
+
 ### Breaking changes in `2.x`
 
-If you are upgrading from version `1.x` please make sure you are not using the `errorInfo` object.
-The hook itself and the `renderError` callback no longer provide this object.
+While upgrading from version `1.x` make sure you are not using the `errorInfo` object.
+The hook and the `renderError` callback no longer provide this object.
 
-For advanced use, please refer to [Custom handling of error and errorInfo](#custom-handling-of-error-and-errorinfo).
+For advanced use, please refer to [Custom handling of error and errorInfo](#handling-error-and-errorinfo-outside-of-markup).
 
 ## Examples and usage
 
@@ -34,7 +40,7 @@ import { useErrorBoundary } from "use-error-boundary"
 import useErrorBoundary from "use-error-boundary"
 ```
 
-Please read more info on the [returned properties](#returned-properties) by the hook.
+Learn more about the [properties that are returned](#returned-properties).
 
 ```javascript
 const MyComponent = () => {
@@ -46,17 +52,18 @@ const MyComponent = () => {
     reset
   } = useErrorBoundary()
 
-  ...
+  //...
 
 }
 ```
 
-### Use without render props
+### Usage without render props
 
-Wrap your components in the provided `ErrorBoundary`,
-if it catches an error the hook provides you with the changed state and the boundary Component will render nothing. So you have to handle rendering some error display yourself.
+Wrap your components in the provided `ErrorBoundary`.
+When it catches an error the hook provides you the changed error-state and the boundary Component will render nothing.
+You have to handle rendering some error display yourself.
 
-If you want the boundary to also render your error display, you can [use it with render props](#use-with-render-props)
+You can get the ErrorBoundary component to render your custom error display by [using the `renderError` render-prop.](#use-with-render-props)
 
 ```javascript
 const JustRenderMe = () => {
@@ -80,13 +87,13 @@ const MyComponent = () => {
 }
 ```
 
-### Use with render props
+### Usage with render props
 
-Optionally, you can pass a `render` and `renderError` function to render the components to display errors in the boundary itself:
+Optionally, you can pass a `render` and `renderError` function to render your UI and error-state inside the boundary.
 
 ```javascript
 /**
- * The renderError function also passes the error and errorInfo, so that you can display it using
+ * The renderError function also passes the error, so that you can display it using
  * render props.
  */
 return (
@@ -97,9 +104,9 @@ return (
 )
 ```
 
-## Custom handling of `error` and `errorInfo`
+## Handling `error` and `errorInfo` outside of markup
 
-The hook now accepts an `options` object that you can pass a `onDidCatch` callback that gets called when the ErrorBoundary catches an error.
+The hook now accepts an `options` object that you can pass a `onDidCatch` callback that gets called when the ErrorBoundary catches an error. Use this for logging or reporting of errors.
 
 ```js
 useErrorBoundary({
@@ -113,21 +120,46 @@ useErrorBoundary({
 
 These are the properties of the returned Object:
 
-| Property        | Type                   | Description                                                                                                                                                                                                                                                                          |
-| --------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `ErrorBoundary` | React Component        | Special error boundary component that provides state changes to the hook. <br>:warning: **You need to use this as the error boundary! Otherwise, the state will not update when errors are caught!** <br> The ErrorBoundary is **guaranteed referential equality** across rerenders. |
-| `didCatch`      | Boolean                | `true` if an error has been caught                                                                                                                                                                                                                                                   |
-| `error`         | Error Object or `null` | The error caught by the Boundary                                                                                                                                                                                                                                                     |
-| `reset`         | Function               | A function to reset the error state of the hook and the boundary. This replaces the error boundary and forces react to newly render it.                                                                                                                                              |
+### `ErrorBoundary`
+`Type: React Component`
+
+
+Special error boundary component that provides state changes to the hook.
+
+:warning: **You need to use this as the error boundary! Otherwise, the state will not update when errors are caught!**
+
+The ErrorBoundary is **guaranteed referential equality** across rerenders and only updates after a reset.
+
+### `didCatch`
+`Type: boolean`
+
+The error state, `true` if an error has ben caught.
+
+
+### `error`
+`Type: any | null`
+
+The error caught by the boundary, or `null`.
+
+### `reset`
+`Type: function`
+
+Function the reset the error state.
+Forces react to recreate the boundary by creating a new ErrorBoundary
+
+Your boundary can now catch errors again.
 
 If you are searching for the `errorInfo` property, please read [Breaking Changes in 2.x](#breaking-changes-in-2x).
 
-## Why should I use this?
+## Why should I use this hook?
 
 React does not provide a way to catch errors within the same functional component and you have to handle that in a class Component with special lifecycle methods.
-If you are new to ErrorBoundaries, I recommend implementing this yourself!
 
-This packages purpose is to provide an easy drop in replacement for projects that are being migrated to hooks and to pull the error presentation out of the boundary itself by putting it on the same level you are catching the errors.
+If you are new to ErrorBoundaries, building this yourself is a good way to get started!
+
+This packages purpose is to provide an easy drop in replacement for projects that are being migrated to hooks.
+
+This also pulls the error presentation out of the error boundary, and on the same level you are handling errors.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ const MyComponent = () => {
   const {
     ErrorBoundary,
     didCatch,
-    error
+    error,
+    reset
   } = useErrorBoundary()
 
   ...
@@ -112,11 +113,12 @@ useErrorBoundary({
 
 These are the properties of the returned Object:
 
-| Property        | Type                   | Description                                                                                                                                                                                                                                                                           |
-| --------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Property        | Type                   | Description                                                                                                                                                                                                                                                                          |
+| --------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `ErrorBoundary` | React Component        | Special error boundary component that provides state changes to the hook. <br>:warning: **You need to use this as the error boundary! Otherwise, the state will not update when errors are caught!** <br> The ErrorBoundary is **guaranteed referential equality** across rerenders. |
-| `didCatch`      | Boolean                | `true` if an error has been caught                                                                                                                                                                                                                                               |
+| `didCatch`      | Boolean                | `true` if an error has been caught                                                                                                                                                                                                                                                   |
 | `error`         | Error Object or `null` | The error caught by the Boundary                                                                                                                                                                                                                                                     |
+| `reset`         | Function               | A function to reset the error state of the hook and the boundary. This replaces the error boundary and forces react to newly render it.                                                                                                                                              |
 
 If you are searching for the `errorInfo` property, please read [Breaking Changes in 2.x](#breaking-changes-in-2x).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "use-error-boundary",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-error-boundary",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "React hook for using error boundaries",
   "source": "src/index.ts",
   "main": "lib/index.js",

--- a/src/ErrorBoundary.ts
+++ b/src/ErrorBoundary.ts
@@ -1,4 +1,4 @@
-import { PureComponent } from "react"
+import { PureComponent, Ref } from "react"
 
 export type ErrorObject = {
   error: any
@@ -65,6 +65,7 @@ export class ErrorBoundary extends PureComponent<
   componentDidCatch(error: any, errorInfo: any) {
     return this.props.onDidCatch(error, errorInfo)
   }
+  
   /**
    * Render children or fallback ui depending on the error state.
    *

--- a/src/ErrorBoundary.ts
+++ b/src/ErrorBoundary.ts
@@ -1,4 +1,4 @@
-import { PureComponent, Ref } from "react"
+import { PureComponent } from "react"
 
 export type ErrorObject = {
   error: any
@@ -65,7 +65,7 @@ export class ErrorBoundary extends PureComponent<
   componentDidCatch(error: any, errorInfo: any) {
     return this.props.onDidCatch(error, errorInfo)
   }
-  
+
   /**
    * Render children or fallback ui depending on the error state.
    *


### PR DESCRIPTION
Resetting the ErrorBoundary can be useful in certain usecases, see #21 

# Additions
- Introduces a `reset` function returned from the hook
- Resetting the error renders a completely new boundary
- Bumped version to 2.0.5

Closes #21 